### PR TITLE
align database methods to bw2023 names

### DIFF
--- a/proxy-api/src/main/java/com/andrei1058/bedwars/proxy/api/BedWars.java
+++ b/proxy-api/src/main/java/com/andrei1058/bedwars/proxy/api/BedWars.java
@@ -35,9 +35,9 @@ public interface BedWars {
      */
     void setPartyAdapter(Party partyAdapter);
 
-    Database getDatabaseUtil();
+    Database getRemoteDatabase();
 
-    void setDatabaseAdapter(Database database);
+    void setRemoteDatabase(Database database);
 
     interface LanguageUtil {
         /**

--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/API.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/API.java
@@ -52,12 +52,12 @@ public class API implements BedWars {
     }
 
     @Override
-    public Database getDatabaseUtil() {
+    public Database getRemoteDatabase() {
         return BedWarsProxy.getRemoteDatabase();
     }
 
     @Override
-    public void setDatabaseAdapter(Database database) {
+    public void setRemoteDatabase(Database database) {
         BedWarsProxy.setRemoteDatabase(database);
     }
 }


### PR DESCRIPTION
- Rename `getDatabaseUtil` to `getRemoteDatabase`
- Rename `setDatabaseAdapter `to `setRemoteDatabase`